### PR TITLE
docs: fix the overflow issue in mobile screens

### DIFF
--- a/docs/src/components/LayoutDocs.js
+++ b/docs/src/components/LayoutDocs.js
@@ -124,6 +124,7 @@ export const LayoutDocs = props => {
       <style jsx>{`
         .docs {
           min-width: calc(100% - 300px - 1rem - 200px);
+          word-wrap: break-word;
         }
       `}</style>
     </>


### PR DESCRIPTION
this branch should fix the overflow issue in mobile devices. The issue was raised on Discord.  

<img width="373" alt="Screenshot 2020-10-01 at 11 52 08 PM" src="https://user-images.githubusercontent.com/28605803/94833422-af938c80-0441-11eb-87b6-b1c5aa536535.png">

