### PR TITLE
Idea/export use chart context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Chart } from './components/Chart'
 export * from './types'
+export { default as useChartContext } from './utils/chartContext'

--- a/src/utils/chartContext.tsx
+++ b/src/utils/chartContext.tsx
@@ -15,5 +15,8 @@ export function ChartContextProvider<TDatum>({
 }
 
 export default function useChartContext<TDatum>() {
-  return React.useContext(chartContext)() as ChartContextValue<TDatum>
+  const ctx = React.useContext(chartContext)() as ChartContextValue<TDatum>
+  if (!ctx)
+    throw new Error('useChartContext can only be used within a Chart Provider')
+  return ctx as ChartContextValue<TDatum>
 }


### PR DESCRIPTION
I made this suggestion in the ideas discussion - https://github.com/TanStack/react-charts/discussions/294
This simply exports the useChartContext hook. I also changed the hook to throw an error if it is not within the provider. Finally, I had to set the type of the exported ctx using an "as". 

I thought this was an easier solution than passing the context as an argument to the renderSVG function (renderSVG: (props)=> <SomeComponent {...props} /> or renderSVG: (ctx)=> <SomeComponent context={ctx} />)