### PR TITLE
d3-color REDoS version patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,5 +138,8 @@
     "d3-time": "^2.1.1",
     "d3-time-format": "^4.1.0",
     "ts-toolbelt": "^9.6.0"
+  },
+  "resolutions": {
+    "d3-scale/d3-interpolate/d3-color": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,10 +2523,10 @@ d3-array@2, d3-array@^2.12.1, d3-array@^2.3.0:
   dependencies:
     internmap "1 - 2"
 
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+"d3-color@1 - 2", d3-color@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
 d3-delaunay@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
overrides the version of d3-color used by d3-scale -> d3-interpolate to use 3.1.0, which remediates
https://security.snyk.io/vuln/SNYK-JS-D3COLOR-1076592

This addresses #328, and can be removed when d3/d3-interpolate#105 is reopened and merged.

LMK if there is a CLA or other formalities before merge. We are also patching in our install, but wanted to share more broadly in the meantime if this is a nit for react-charts users.