### PR TITLE
Implement showDatumInTooltip in TooltipOptions to allow hiding certain datums in regular TooltipRenderer.

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -41,6 +41,7 @@ export function defaultTooltip<TDatum>(
     arrowPadding: options.arrowPadding ?? 7,
     // anchor: options.anchor ?? 'closest',
     render: options.render ?? TooltipRenderer,
+    showDatumInTooltip: options.showDatumInTooltip ?? (() => true),
   }
 }
 

--- a/src/components/TooltipRenderer.tsx
+++ b/src/components/TooltipRenderer.tsx
@@ -54,7 +54,8 @@ function TooltipRenderer<TDatum>(props: TooltipRendererProps<TDatum>) {
 
   const { tooltip, dark } = props.getOptions()
 
-  const groupDatums = props.focusedDatum?.tooltipGroup ?? []
+  const groupDatums = (props.focusedDatum?.tooltipGroup ?? [])
+    .filter((datum) => tooltip.showDatumInTooltip?.(datum) ?? true);
 
   const resolvedShowCount = showCount % 2 === 0 ? showCount : showCount + 1
   const length = groupDatums.length

--- a/src/components/TooltipRenderer.tsx
+++ b/src/components/TooltipRenderer.tsx
@@ -54,8 +54,9 @@ function TooltipRenderer<TDatum>(props: TooltipRendererProps<TDatum>) {
 
   const { tooltip, dark } = props.getOptions()
 
-  const groupDatums = (props.focusedDatum?.tooltipGroup ?? [])
-    .filter((datum) => tooltip.showDatumInTooltip?.(datum) ?? true);
+  const groupDatums = (props.focusedDatum?.tooltipGroup ?? []).filter(
+    datum => tooltip.showDatumInTooltip?.(datum) ?? true
+  )
 
   const resolvedShowCount = showCount % 2 === 0 ? showCount : showCount + 1
   const length = groupDatums.length

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,8 @@ export type TooltipOptions<TDatum> = {
   render?: (props: TooltipRendererProps<TDatum>) => React.ReactNode
   // formatSecondary?: (d: unknown) => string | number
   // formatTertiary?: (d: unknown) => string | number
-  invert?: boolean
+  invert?: boolean,
+  showDatumInTooltip?: (datum: Datum<TDatum>) => boolean
 }
 
 export type ResolvedTooltipOptions<TDatum> = TSTB.Object.Required<


### PR DESCRIPTION
I wanted to be able to hide datums with value 0 in my chart and couldn't find a way to do this with the current implementation, except write my own TooltipRenderer which I didn't feel like doing.

So this PR will add showDatumInTooltip in TooltipOptions to be able to filter datums that are shown in the regular TooltipRenderer.

@tannerlinsley Could you take a look?

## Example usage

```tsx
<Chart
    options={{
        data,
        primaryAxis,
        secondaryAxes,
        tooltip: {
            showDatumInTooltip: (datum) => {
                return datum.originalDatum.value !== 0;
            }
        }
    }}
/>
```