### PR TITLE
Add overrides construct for npm only compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,5 +141,12 @@
   },
   "resolutions": {
     "d3-scale/d3-interpolate/d3-color": "^3.1.0"
+  },
+  "overrides": {
+    "d3-scale": {
+      "d3-interpolate": {
+        "d3-color": "^3.1.0"
+      }
+    }
   }
 }


### PR DESCRIPTION
This will allow build chains that are using pure `npm` and not `yarn` to take advantage of the security fix for `d3-color`.